### PR TITLE
Fix concept write hooks to use the canonical CLI

### DIFF
--- a/.github/workflows/concept-hooks.yml
+++ b/.github/workflows/concept-hooks.yml
@@ -1,0 +1,28 @@
+name: concept-hooks
+
+on:
+  pull_request:
+    paths:
+      - "plugins/repoql/scripts/concepts-write-hook.sh"
+      - "plugins/repoql-codex/scripts/concepts-write-hook.sh"
+      - "tests/test_concept_write_hooks.py"
+      - ".github/workflows/concept-hooks.yml"
+  push:
+    branches: [main]
+    paths:
+      - "plugins/repoql/scripts/concepts-write-hook.sh"
+      - "plugins/repoql-codex/scripts/concepts-write-hook.sh"
+      - "tests/test_concept_write_hooks.py"
+      - ".github/workflows/concept-hooks.yml"
+
+jobs:
+  hooks:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: command -v jq
+      - run: python3 -m unittest discover -s tests -p 'test_concept_write_hooks.py'

--- a/plugins/repoql-codex/.codex-plugin/plugin.json
+++ b/plugins/repoql-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repoql-codex",
-  "version": "1.1.0+codex.20260819100647",
+  "version": "1.1.0+codex.20260906085208",
   "description": "Queryable code intelligence \u2014 explore codebase structure without reading files.",
   "author": {
     "name": "Clanker Tools",

--- a/plugins/repoql-codex/scripts/concepts-write-hook.sh
+++ b/plugins/repoql-codex/scripts/concepts-write-hook.sh
@@ -1,124 +1,53 @@
 #!/bin/bash
-# Surface on-disk concepts relevant to every file in a Codex apply_patch call.
-# Fail open: malformed concepts or unavailable tooling must never block an edit.
-trap 'exit 0' ERR
+# The host owns relevance matching, ranking, and once-per-session suppression.
+# Hook failures report to stderr but must never block an edit.
+set -o pipefail
+trap 'printf "%s\n" "RepoQL concept hints: hook failed; continuing the edit." >&2; exit 0' ERR
 
 command -v jq >/dev/null 2>&1 || exit 0
-
-input=$(cat)
-patch=$(jq -r '.tool_input.command // .tool_input.patch // empty' <<<"$input")
-session=$(jq -r '.session_id // .turn_id // empty' <<<"$input")
-workspace=$(jq -r '.cwd // empty' <<<"$input")
-[ -n "$patch" ] || exit 0
-[ -d "$workspace" ] && cd "$workspace"
-
-files=$(printf '%s\n' "$patch" \
-    | sed -nE 's/^\*\*\* (Update|Add|Delete) File: //p' \
-    | awk '!seen[$0]++' \
-    | head -8)
-[ -n "$files" ] || exit 0
-
-concept_root="$workspace/.repoql/concepts"
-[ -d "$concept_root" ] || exit 0
-
-# Normalize every changed path to the file:/// URI shape used by relevance
-# globs in concept frontmatter.
-target_uris=""
-while IFS= read -r file; do
-    [ -n "$file" ] || continue
-    case "$file" in
-        file://*) target_uri="$file" ;;
-        "$workspace"/*) target_uri="file:///${file#"$workspace"/}" ;;
-        *) target_uri="file:///${file#./}" ;;
-    esac
-    target_uris+="$target_uri"$'\n'
-done < <(printf '%s\n' "$files")
-
-matches_relevance() {
-    local relevance="$1"
-    local raw pattern target matched=0
-    local -a patterns
-    IFS=';' read -r -a patterns <<<"$relevance"
-
-    for raw in "${patterns[@]}"; do
-        pattern=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        [ -n "$pattern" ] || continue
-        negative=""
-        if [[ "$pattern" == !* ]]; then
-            negative=1
-            pattern="${pattern#!}"
-        fi
-        [[ "$pattern" == *://* ]] || pattern="file:///${pattern#./}"
-
-        while IFS= read -r target; do
-            [ -n "$target" ] || continue
-            if [[ "$target" == $pattern ]]; then
-                [ -n "$negative" ] && return 1
-                matched=1
-            fi
-        done <<<"$target_uris"
-    done
-
-    [ "$matched" -eq 1 ]
+command -v rql >/dev/null 2>&1 || {
+    printf '%s\n' 'RepoQL concept hints: rql is unavailable; continuing the edit.' >&2
+    exit 0
 }
 
-plugin_data="${PLUGIN_DATA:-${CLAUDE_PLUGIN_DATA:-${TMPDIR:-/tmp}/repoql-codex}}"
-session_key=$(printf '%s' "${session:-ambient}" | tr -c 'A-Za-z0-9._-' '_')
-seen_dir="$plugin_data/concept-hints"
-mkdir -p "$seen_dir" 2>/dev/null || exit 0
-seen_file="$seen_dir/$session_key.seen"
-touch "$seen_file" 2>/dev/null || exit 0
+input=$(cat)
+session=$(jq -r '.session_id // empty' <<<"$input")
+workspace=$(jq -r '.cwd // empty' <<<"$input")
+[ -d "$workspace" ] || workspace="$PWD"
+cd "$workspace"
+[ -n "$session" ] || exit 0
+
+# Include both sides of a move, as well as added, updated, and deleted files.
+patch=$(jq -r '.tool_input.command // .tool_input.patch // empty' <<<"$input")
+files=$(printf '%s\n' "$patch" \
+    | sed -nE 's/^\*\*\* (Update File|Add File|Delete File|Move to): //p' \
+    | awk '!seen[$0]++')
+[ -n "$files" ] || exit 0
 
 context=""
-count=0
-while IFS= read -r concept_file; do
-    [ "$count" -ge 5 ] && break
-    concept_key="${concept_file#"$concept_root"/}"
-    grep -Fqx -- "$concept_key" "$seen_file" 2>/dev/null && continue
-
-    relevance=$(awk '
-        NR == 1 && $0 == "---" { frontmatter=1; next }
-        frontmatter && $0 == "---" { exit }
-        frontmatter && /^relevance:[[:space:]]*/ {
-            sub(/^relevance:[[:space:]]*/, "")
-            gsub(/^"|"$/, "")
-            print
-            exit
-        }
-    ' "$concept_file")
-    [ -n "$relevance" ] || continue
-    matches_relevance "$relevance" || continue
-
-    invariant=$(awk '
-        /^\*\*Invariant\*\*[[:space:]]*$/ { capture=1; next }
-        capture && $0 !~ /^[[:space:]]*$/ { print; exit }
-    ' "$concept_file")
-    [ -n "$invariant" ] || continue
-
-    why=$(awk '
-        /^\*\*Why\*\*[[:space:]]*$/ { capture=1; next }
-        capture && /^\*\*/ { exit }
-        capture && /^##[[:space:]]/ { exit }
-        capture {
-            if (started || $0 !~ /^[[:space:]]*$/) {
-                print
-                started=1
-            }
-        }
-    ' "$concept_file")
-
-    entry="concept:///$concept_key"$'\t'"$invariant"
-    if [ -n "$why" ]; then
-        why=$(printf '%s\n' "$why" | sed 's/^/  /')
-        entry+=$'\n'"  why:"$'\n'"$why"
+remaining=5
+file_count=0
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    [ "$file_count" -lt 8 ] || break
+    file_count=$((file_count + 1))
+    # Query paths separately so newly created files need not exist in the index.
+    if ! hints=$(rql concept hints "$file" --session "$session" --limit "$remaining" --json); then
+        printf '%s\n' 'RepoQL concept hints: CLI failed; continuing the edit.' >&2
+        continue
     fi
-    if [ -n "$context" ]; then
-        context+=$'\n\n'
+    if ! count=$(jq -er '.concepts | if type == "array" then length else error("expected concepts array") end' <<<"$hints"); then
+        printf '%s\n' 'RepoQL concept hints: invalid CLI response; continuing the edit.' >&2
+        continue
     fi
+    [ "$count" -gt 0 ] || continue
+    entry=$(jq -r '.concepts[] | .uri + "\t" + .invariant +
+        (if (.why // "") != "" then "\n  why: " + .why else "" end)' <<<"$hints")
+    [ -z "$context" ] || context+=$'\n\n'
     context+="$entry"
-    printf '%s\n' "$concept_key" >>"$seen_file"
-    count=$((count + 1))
-done < <(find "$concept_root" -type f -name '*.md' ! -iname 'readme.md' -print 2>/dev/null | sort)
+    remaining=$((remaining - count))
+    [ "$remaining" -gt 0 ] || break
+done <<<"$files"
 
 [ -n "$context" ] || exit 0
 jq -n --arg ctx "$context" '{

--- a/plugins/repoql/.claude-plugin/plugin.json
+++ b/plugins/repoql/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repoql",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Queryable code intelligence — explore codebase structure without reading files.",
   "author": {
     "name": "Clanker Tools",

--- a/plugins/repoql/scripts/concepts-write-hook.sh
+++ b/plugins/repoql/scripts/concepts-write-hook.sh
@@ -1,131 +1,56 @@
 #!/bin/bash
-# Surface on-disk concepts relevant to files in a Claude Write/Edit/MultiEdit call.
-# Fail open: malformed concepts or unavailable tooling must never block an edit.
-trap 'exit 0' ERR
+# The host owns relevance matching, ranking, and once-per-session suppression.
+# Hook failures report to stderr but must never block an edit.
+set -o pipefail
+trap 'printf "%s\n" "RepoQL concept hints: hook failed; continuing the edit." >&2; exit 0' ERR
 
 command -v jq >/dev/null 2>&1 || exit 0
+command -v rql >/dev/null 2>&1 || {
+    printf '%s\n' 'RepoQL concept hints: rql is unavailable; continuing the edit.' >&2
+    exit 0
+}
 
 input=$(cat)
 session=$(jq -r '.session_id // empty' <<<"$input")
 workspace=$(jq -r '.cwd // empty' <<<"$input")
 [ -d "$workspace" ] || workspace="$PWD"
 cd "$workspace"
+[ -n "$session" ] || exit 0
 
+# Claude Write/Edit uses file_path; multi-file adapters may supply edits[].
 files=$(jq -r '
-  [
-    .tool_input.file_path?,
-    .tool_input.path?,
-    (.tool_input.edits[]?.file_path?),
-    (.tool_input.edits[]?.path?)
-  ]
-  | map(select(type == "string" and length > 0))
-  | unique[]
-' <<<"$input" | head -8)
+  [.tool_input.file_path?, .tool_input.path?,
+   (.tool_input.edits[]?.file_path?), (.tool_input.edits[]?.path?)]
+  | map(select(type == "string" and length > 0)) | unique[]
+' <<<"$input")
 [ -n "$files" ] || exit 0
 
-concept_root="$workspace/.repoql/concepts"
-[ -d "$concept_root" ] || exit 0
-
-# Normalize changed paths to the file:/// URI shape used by relevance globs.
-target_uris=""
+context=""
+remaining=5
+file_count=0
 while IFS= read -r file; do
     [ -n "$file" ] || continue
-    case "$file" in
-        file://*) target_uri="$file" ;;
-        "$workspace"/*) target_uri="file:///${file#"$workspace"/}" ;;
-        *) target_uri="file:///${file#./}" ;;
-    esac
-    target_uris+="$target_uri"$'\n'
-done < <(printf '%s\n' "$files")
-
-matches_relevance() {
-    local relevance="$1"
-    local raw pattern target matched=0
-    local -a patterns
-    IFS=';' read -r -a patterns <<<"$relevance"
-
-    for raw in "${patterns[@]}"; do
-        pattern=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-        [ -n "$pattern" ] || continue
-        negative=""
-        if [[ "$pattern" == !* ]]; then
-            negative=1
-            pattern="${pattern#!}"
-        fi
-        [[ "$pattern" == *://* ]] || pattern="file:///${pattern#./}"
-
-        while IFS= read -r target; do
-            [ -n "$target" ] || continue
-            if [[ "$target" == $pattern ]]; then
-                [ -n "$negative" ] && return 1
-                matched=1
-            fi
-        done <<<"$target_uris"
-    done
-
-    [ "$matched" -eq 1 ]
-}
-
-plugin_data="${CLAUDE_PLUGIN_DATA:-${PLUGIN_DATA:-${TMPDIR:-/tmp}/repoql-claude}}"
-session_key=$(printf '%s' "${session:-ambient}" | tr -c 'A-Za-z0-9._-' '_')
-seen_dir="$plugin_data/concept-hints"
-mkdir -p "$seen_dir" 2>/dev/null || exit 0
-seen_file="$seen_dir/$session_key.seen"
-touch "$seen_file" 2>/dev/null || exit 0
-
-context=""
-count=0
-while IFS= read -r concept_file; do
-    [ "$count" -ge 5 ] && break
-    concept_key="${concept_file#"$concept_root"/}"
-    grep -Fqx -- "$concept_key" "$seen_file" 2>/dev/null && continue
-
-    relevance=$(awk '
-        NR == 1 && $0 == "---" { frontmatter=1; next }
-        frontmatter && $0 == "---" { exit }
-        frontmatter && /^relevance:[[:space:]]*/ {
-            sub(/^relevance:[[:space:]]*/, "")
-            gsub(/^"|"$/, "")
-            print
-            exit
-        }
-    ' "$concept_file")
-    [ -n "$relevance" ] || continue
-    matches_relevance "$relevance" || continue
-
-    invariant=$(awk '
-        /^\*\*Invariant\*\*[[:space:]]*$/ { capture=1; next }
-        capture && $0 !~ /^[[:space:]]*$/ { print; exit }
-    ' "$concept_file")
-    [ -n "$invariant" ] || continue
-
-    why=$(awk '
-        /^\*\*Why\*\*[[:space:]]*$/ { capture=1; next }
-        capture && /^\*\*/ { exit }
-        capture && /^##[[:space:]]/ { exit }
-        capture {
-            if (started || $0 !~ /^[[:space:]]*$/) {
-                print
-                started=1
-            }
-        }
-    ' "$concept_file")
-
-    entry="concept:///$concept_key"$'\t'"$invariant"
-    if [ -n "$why" ]; then
-        why=$(printf '%s\n' "$why" | sed 's/^/  /')
-        entry+=$'\n'"  why:"$'\n'"$why"
+    [ "$file_count" -lt 8 ] || break
+    file_count=$((file_count + 1))
+    # Query paths separately so newly created files need not exist in the index.
+    if ! hints=$(rql concept hints "$file" --session "$session" --limit "$remaining" --json); then
+        printf '%s\n' 'RepoQL concept hints: CLI failed; continuing the edit.' >&2
+        continue
     fi
-    if [ -n "$context" ]; then
-        context+=$'\n\n'
+    if ! count=$(jq -er '.concepts | if type == "array" then length else error("expected concepts array") end' <<<"$hints"); then
+        printf '%s\n' 'RepoQL concept hints: invalid CLI response; continuing the edit.' >&2
+        continue
     fi
+    [ "$count" -gt 0 ] || continue
+    entry=$(jq -r '.concepts[] | .uri + "\t" + .invariant +
+        (if (.why // "") != "" then "\n  why: " + .why else "" end)' <<<"$hints")
+    [ -z "$context" ] || context+=$'\n\n'
     context+="$entry"
-    printf '%s\n' "$concept_key" >>"$seen_file"
-    count=$((count + 1))
-done < <(find "$concept_root" -type f -name '*.md' ! -iname 'readme.md' -print 2>/dev/null | sort)
+    remaining=$((remaining - count))
+    [ "$remaining" -gt 0 ] || break
+done <<<"$files"
 
 [ -n "$context" ] || exit 0
-
 jq -n --arg ctx "$context" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",

--- a/tests/test_concept_write_hooks.py
+++ b/tests/test_concept_write_hooks.py
@@ -1,0 +1,152 @@
+"""Exercise the plugin entrypoints with literal harness payloads and a fake CLI."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ConceptWriteHooksTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name).resolve()
+        self.workspace = self.root / 'workspace with spaces'
+        self.workspace.mkdir()
+        self.bin = self.root / 'bin'
+        self.bin.mkdir()
+        self.log = self.root / 'calls.jsonl'
+        self.env = {**os.environ, 'PATH': f'{self.bin}:{os.environ["PATH"]}',
+                    'HOOK_CALLS': str(self.log), 'HOOK_MODE': 'normal'}
+        (self.bin / 'rql').write_text('''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+args = sys.argv[1:]
+with open(os.environ['HOOK_CALLS'], 'a') as log:
+    log.write(json.dumps({'args': args, 'cwd': os.getcwd()}) + '\\n')
+if args[:2] != ['concept', 'hints']:
+    print('retired command', file=sys.stderr)
+    sys.exit(2)
+mode = os.environ['HOOK_MODE']
+if mode == 'failure':
+    print('host unavailable', file=sys.stderr)
+    sys.exit(1)
+if mode == 'malformed':
+    print('not json')
+    sys.exit(0)
+limit = int(args[args.index('--limit') + 1])
+terms = [] if mode == 'empty' else [
+    {'uri': 'concept:///Rule.md', 'invariant': 'Preserve the contract.', 'why': 'Callers depend on it.'}
+]
+if mode == 'many':
+    terms = [{'uri': f'concept:///{args[2]}-{i}', 'invariant': 'Rule'} for i in range(limit)]
+print(json.dumps({'targetUri': args[2], 'concepts': terms}))
+''')
+        (self.bin / 'rql').chmod(0o755)
+
+    def run_hook(self, harness, files=None, **overrides):
+        files = files if files is not None else ['src/File with spaces.cs']
+        if harness == 'repoql':
+            payload = {'tool_name': 'MultiEdit', 'tool_input': {'edits': [{'file_path': f} for f in files]}}
+        else:
+            payload = {'tool_name': 'apply_patch', 'tool_input': {'patch': '\n'.join(f'*** Update File: {f}' for f in files)}}
+        payload.update(cwd=str(self.workspace), session_id='session-123')
+        payload.update(overrides)
+        result = subprocess.run(['bash', str(ROOT / 'plugins' / harness / 'scripts/concepts-write-hook.sh')],
+                                input=json.dumps(payload), text=True, capture_output=True,
+                                env=self.env, cwd=self.root, timeout=5)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result
+
+    def calls(self):
+        return [json.loads(line) for line in self.log.read_text().splitlines()] if self.log.exists() else []
+
+    def test_current_command_session_workspace_and_context(self):
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                result = self.run_hook(harness)
+                self.assertEqual(result.stderr, '')
+                output = json.loads(result.stdout)['hookSpecificOutput']
+                self.assertEqual(output['hookEventName'], 'PreToolUse')
+                self.assertNotIn('permissionDecision', output)
+                self.assertIn('concept:///Rule.md\tPreserve the contract.', output['additionalContext'])
+                self.assertIn('Callers depend on it.', output['additionalContext'])
+                self.assertEqual(self.calls()[-1], {'cwd': str(self.workspace), 'args':
+                    ['concept', 'hints', 'src/File with spaces.cs', '--session', 'session-123', '--limit', '5', '--json']})
+
+    def test_each_unique_path_is_queried(self):
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                before = len(self.calls())
+                self.run_hook(harness, ['new.cs', 'existing.cs', 'new.cs'])
+                calls = self.calls()[before:]
+                self.assertEqual({c['args'][2] for c in calls}, {'new.cs', 'existing.cs'})
+                self.assertEqual(len(calls), 2)
+
+    def test_total_context_cap(self):
+        self.env['HOOK_MODE'] = 'many'
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                before = len(self.calls())
+                result = self.run_hook(harness, ['a.cs', 'b.cs'])
+                context = json.loads(result.stdout)['hookSpecificOutput']['additionalContext']
+                self.assertEqual(context.count('concept:///'), 5)
+                self.assertEqual(len(self.calls()) - before, 1)
+
+    def test_empty_results_are_quiet(self):
+        self.env['HOOK_MODE'] = 'empty'
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                result = self.run_hook(harness)
+                self.assertEqual((result.stdout, result.stderr), ('', ''))
+                self.assertTrue(self.calls())
+
+    def test_failures_are_visible_but_do_not_block(self):
+        for mode in ['failure', 'malformed']:
+            self.env['HOOK_MODE'] = mode
+            for harness in ['repoql', 'repoql-codex']:
+                with self.subTest(harness=harness, mode=mode):
+                    result = self.run_hook(harness)
+                    self.assertEqual(result.stdout, '')
+                    self.assertIn('RepoQL concept hints:', result.stderr)
+
+    def test_missing_session_does_not_share_ambient_dedupe(self):
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                result = self.run_hook(harness, session_id='')
+                self.assertEqual(result.stdout, '')
+                self.assertFalse(self.calls())
+
+    def test_codex_add_delete_move_and_command_field(self):
+        result = self.run_hook('repoql-codex', tool_input={'command':
+            '*** Begin Patch\n*** Add File: added.cs\n+new\n*** Delete File: deleted.cs\n'
+            '*** Update File: old.cs\n*** Move to: moved.cs\n*** End Patch'})
+        self.assertTrue(result.stdout)
+        self.assertEqual({c['args'][2] for c in self.calls()}, {'added.cs', 'deleted.cs', 'old.cs', 'moved.cs'})
+
+    def test_claude_write_file_path(self):
+        result = self.run_hook('repoql', tool_name='Write', tool_input={'file_path': str(self.workspace / 'new.cs')})
+        self.assertTrue(result.stdout)
+        self.assertEqual(self.calls()[0]['args'][2], str(self.workspace / 'new.cs'))
+
+    def test_large_edits_keep_the_existing_eight_file_bound(self):
+        self.env['HOOK_MODE'] = 'empty'
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                before = len(self.calls())
+                self.run_hook(harness, [f'{i}.cs' for i in range(20)])
+                self.assertEqual(len(self.calls()) - before, 8)
+
+    def test_no_paths_are_quiet(self):
+        for harness in ['repoql', 'repoql-codex']:
+            with self.subTest(harness=harness):
+                result = self.run_hook(harness, [])
+                self.assertEqual(result.stdout, '')
+                self.assertFalse(self.calls())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The installed Claude write hook calls the retired `rql concepts` command, discards the error, and returns no context. The newer plugin source also duplicates concept matching in shell, so Claude and Codex can disagree with the canonical host behavior.

Both write hooks now call `rql concept hints` with the file path and harness session ID. The host owns relevance matching, ranking, and session suppression. The adapters retain the five-concept and eight-file bounds, support multi-file edits and Codex moves, and report CLI failures on stderr while allowing the edit to proceed. Claude's patch version and Codex's cachebuster advance so updates replace the cached scripts.

Validation:
- Ten regression tests pass for command arguments, session/workspace forwarding, context rendering, file bounds, multi-file edits, moves, empty results, and failures. Added Ubuntu/macOS CI coverage.
- Codex plugin manifest validation and shell syntax checks pass.
- Live probes of the installed scripts returned five concepts, five different concepts, then no output for the same session. A fresh session received hints again; a not-yet-created file matched successfully. Calls took 205–250 ms against the running local host.

The repaired Claude hook is installed locally, and the Codex plugin was reinstalled from this tested checkout. No rql binary or service deployment is required.
