### PR TITLE
Define known vocabulary after native and RepoQL reads

### DIFF
--- a/.github/workflows/concept-hooks.yml
+++ b/.github/workflows/concept-hooks.yml
@@ -1,18 +1,22 @@
-name: concept-hooks
+name: context-hooks
 
 on:
   pull_request:
     paths:
       - "plugins/repoql/scripts/concepts-write-hook.sh"
       - "plugins/repoql-codex/scripts/concepts-write-hook.sh"
-      - "tests/test_concept_write_hooks.py"
+      - "tests/test_*_hooks.py"
+      - "plugins/*/scripts/vocabulary-read-hook.sh"
+      - "plugins/*/hooks/hooks.json"
       - ".github/workflows/concept-hooks.yml"
   push:
     branches: [main]
     paths:
       - "plugins/repoql/scripts/concepts-write-hook.sh"
       - "plugins/repoql-codex/scripts/concepts-write-hook.sh"
-      - "tests/test_concept_write_hooks.py"
+      - "tests/test_*_hooks.py"
+      - "plugins/*/scripts/vocabulary-read-hook.sh"
+      - "plugins/*/hooks/hooks.json"
       - ".github/workflows/concept-hooks.yml"
 
 jobs:
@@ -25,4 +29,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: command -v jq
-      - run: python3 -m unittest discover -s tests -p 'test_concept_write_hooks.py'
+      - run: python3 -m unittest discover -s tests -p 'test_*_hooks.py'

--- a/plugins/repoql-codex/.codex-plugin/plugin.json
+++ b/plugins/repoql-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repoql-codex",
-  "version": "1.1.0+codex.20260906085208",
+  "version": "1.1.0+codex.20260907000559",
   "description": "Queryable code intelligence \u2014 explore codebase structure without reading files.",
   "author": {
     "name": "Clanker Tools",

--- a/plugins/repoql-codex/README.md
+++ b/plugins/repoql-codex/README.md
@@ -62,8 +62,11 @@ The `research` skill can ask Codex to delegate independent directions to researc
 
 - `SessionStart` bootstraps `rql`, reports imported repositories, and injects `.repoql/concepts/readme.md` (or `README.md`) when present, including after context compaction.
 - `PreToolUse` loads concepts relevant to files touched by `apply_patch` immediately before a change.
+- **PostToolUse (reads)** — defines known terms and aliases from returned text after native `Read`/`read_file` and RepoQL MCP `read` calls. Each definition appears once per session in the serving host; a host restart resets that memory. Scope comes from the read target.
 
-Both hooks fail open: RepoQL being unavailable never blocks a Codex task or edit.
+All hooks fail open: RepoQL being unavailable never blocks a task, read, or edit.
+
+Vocabulary hints require a host and CLI with `rql vocabulary hints` support. Each read can add up to five complete definitions within 2,000 characters. The hook considers the first 65,536 Unicode characters of text, skips errors and image-only results, and does not parse shell reads such as `cat` or `sed`. An older CLI reports a diagnostic and the read continues.
 
 ## Use it
 

--- a/plugins/repoql-codex/hooks/hooks.json
+++ b/plugins/repoql-codex/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Load relevant concepts before writes and inject the repository concepts index when a session starts.",
+  "description": "Load concepts before writes, define known vocabulary after reads, and inject the concepts index at session start.",
   "hooks": {
     "PreToolUse": [
       {
@@ -26,6 +26,20 @@
             "timeout": 240,
             "additionalContextLimit": 12000,
             "statusMessage": "Loading the RepoQL concepts index"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Read|read_file|mcp__.*[Rr][Ee][Pp][Oo][Qq][Ll].*__read)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_ROOT}/scripts/vocabulary-read-hook.sh",
+            "timeout": 5,
+            "additionalContextLimit": 2500,
+            "statusMessage": "Loading repository vocabulary"
           }
         ]
       }

--- a/plugins/repoql-codex/scripts/vocabulary-read-hook.sh
+++ b/plugins/repoql-codex/scripts/vocabulary-read-hook.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Forward delivered text only. The host owns matching, scope, and session suppression.
+set -o pipefail
+trap 'printf "%s\n" "RepoQL vocabulary hints: hook failed; continuing the read." >&2; exit 0' ERR
+
+command -v jq >/dev/null 2>&1 || exit 0
+input=$(cat)
+session=$(jq -r '.session_id // empty' <<<"$input")
+workspace=$(jq -r '.cwd // empty' <<<"$input")
+[ -n "$session" ] && [ -d "$workspace" ] || exit 0
+
+# Do not scan tool arguments, shell commands, images, or failed tool responses.
+if ! jq -e '(.tool_name // "") | test("^(Read|read_file|mcp__.*[Rr][Ee][Pp][Oo][Qq][Ll].*__read)$")' <<<"$input" >/dev/null; then
+    exit 0
+fi
+if jq -e '.tool_response | type == "object" and (.isError == true or .is_error == true)' <<<"$input" >/dev/null; then
+    exit 0
+fi
+target=$(jq -r '(.tool_input.file_path // .tool_input.path // .tool_input.uriGlob // .tool_input.uri // "")
+    | if type == "string" then split(" =>")[0] | split("#")[0] else "" end' <<<"$input")
+[ -n "$target" ] || exit 0
+# Native relative paths resolve from the harness cwd; MCP globs are repository-relative.
+case $(jq -r '.tool_name' <<<"$input") in
+    Read|read_file)
+        case "$target" in
+            /*|[A-Za-z]:*|*://*) ;;
+            *) target="$workspace/$target" ;;
+        esac
+        ;;
+esac
+# 65536 Unicode scalars fit within the CLI's 131072 UTF-16 character limit.
+content=$(jq -r '.tool_response |
+    if type == "string" then .
+    elif type == "object" then
+        if (.file.content? | type) == "string" then .file.content
+        elif (.content? | type) == "string" then .content
+        elif (.content? | type) == "array" then [.content[] | select(.type == "text") | .text | select(type == "string")] | join("\n")
+        else "" end
+    else "" end | .[0:65536]' <<<"$input")
+[ -n "$content" ] || exit 0
+command -v rql >/dev/null 2>&1 || {
+    printf '%s\n' 'RepoQL vocabulary hints: rql is unavailable; continuing the read.' >&2
+    exit 0
+}
+cd "$workspace"
+if ! hints=$(printf '%s' "$content" | REPOQL_CWD="$workspace" rql vocabulary hints "$target" --session "$session" --limit 5 --max-chars 2000); then
+    printf '%s\n' 'RepoQL vocabulary hints: CLI failed; continuing the read.' >&2
+    exit 0
+fi
+[ -n "$hints" ] || exit 0
+jq -n --arg ctx "$hints" '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/plugins/repoql/.claude-plugin/plugin.json
+++ b/plugins/repoql/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repoql",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Queryable code intelligence — explore codebase structure without reading files.",
   "author": {
     "name": "Clanker Tools",

--- a/plugins/repoql/README.md
+++ b/plugins/repoql/README.md
@@ -56,6 +56,9 @@ Auto-activating: **effective-repoql**, **effective-markdown**, **mermaid-diagram
 
 - **SessionStart** — bootstraps the `rql` binary if it's missing (see Installation), then injects a deliberately small orientation: the mounted `github://` repos (directly usable) and a pointer to the `concept://` invariants. Repo structure and docs are large and re-derivable, so the agent pulls them on demand (`read` / `explore`) rather than paying for them every session.
 - **PreToolUse (Write/Edit)** — surfaces the `concept://` invariants relevant to the file being edited, once per session, as extra context just before the write.
+- **PostToolUse (reads)** — defines known terms and aliases from returned text after native `Read`/`read_file` and RepoQL MCP `read` calls. Each definition appears once per session in the serving host; a host restart resets that memory. Scope comes from the read target.
+
+Vocabulary hints require a host and CLI with `rql vocabulary hints` support. Each read can add up to five complete definitions within 2,000 characters. The hook considers the first 65,536 Unicode characters of text, skips errors and image-only results, and does not parse shell reads such as `cat` or `sed`. An older CLI reports a diagnostic and the read continues.
 
 ## How to use it
 

--- a/plugins/repoql/hooks/hooks.json
+++ b/plugins/repoql/hooks/hooks.json
@@ -23,6 +23,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Read|read_file|mcp__.*[Rr][Ee][Pp][Oo][Qq][Ll].*__read)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/vocabulary-read-hook.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/repoql/scripts/vocabulary-read-hook.sh
+++ b/plugins/repoql/scripts/vocabulary-read-hook.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Forward delivered text only. The host owns matching, scope, and session suppression.
+set -o pipefail
+trap 'printf "%s\n" "RepoQL vocabulary hints: hook failed; continuing the read." >&2; exit 0' ERR
+
+command -v jq >/dev/null 2>&1 || exit 0
+input=$(cat)
+session=$(jq -r '.session_id // empty' <<<"$input")
+workspace=$(jq -r '.cwd // empty' <<<"$input")
+[ -n "$session" ] && [ -d "$workspace" ] || exit 0
+
+# Do not scan tool arguments, shell commands, images, or failed tool responses.
+if ! jq -e '(.tool_name // "") | test("^(Read|read_file|mcp__.*[Rr][Ee][Pp][Oo][Qq][Ll].*__read)$")' <<<"$input" >/dev/null; then
+    exit 0
+fi
+if jq -e '.tool_response | type == "object" and (.isError == true or .is_error == true)' <<<"$input" >/dev/null; then
+    exit 0
+fi
+target=$(jq -r '(.tool_input.file_path // .tool_input.path // .tool_input.uriGlob // .tool_input.uri // "")
+    | if type == "string" then split(" =>")[0] | split("#")[0] else "" end' <<<"$input")
+[ -n "$target" ] || exit 0
+# Native relative paths resolve from the harness cwd; MCP globs are repository-relative.
+case $(jq -r '.tool_name' <<<"$input") in
+    Read|read_file)
+        case "$target" in
+            /*|[A-Za-z]:*|*://*) ;;
+            *) target="$workspace/$target" ;;
+        esac
+        ;;
+esac
+# 65536 Unicode scalars fit within the CLI's 131072 UTF-16 character limit.
+content=$(jq -r '.tool_response |
+    if type == "string" then .
+    elif type == "object" then
+        if (.file.content? | type) == "string" then .file.content
+        elif (.content? | type) == "string" then .content
+        elif (.content? | type) == "array" then [.content[] | select(.type == "text") | .text | select(type == "string")] | join("\n")
+        else "" end
+    else "" end | .[0:65536]' <<<"$input")
+[ -n "$content" ] || exit 0
+command -v rql >/dev/null 2>&1 || {
+    printf '%s\n' 'RepoQL vocabulary hints: rql is unavailable; continuing the read.' >&2
+    exit 0
+}
+cd "$workspace"
+if ! hints=$(printf '%s' "$content" | REPOQL_CWD="$workspace" rql vocabulary hints "$target" --session "$session" --limit 5 --max-chars 2000); then
+    printf '%s\n' 'RepoQL vocabulary hints: CLI failed; continuing the read.' >&2
+    exit 0
+fi
+[ -n "$hints" ] || exit 0
+jq -n --arg ctx "$hints" '{hookSpecificOutput: {hookEventName: "PostToolUse", additionalContext: $ctx}}'
+exit 0

--- a/tests/test_vocabulary_read_hooks.py
+++ b/tests/test_vocabulary_read_hooks.py
@@ -1,0 +1,134 @@
+"""Verify delivered-text adapters with literal native and MCP read payloads."""
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESSES = ['repoql', 'repoql-codex']
+
+
+class VocabularyReadHooksTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name).resolve()
+        self.workspace = self.root / 'workspace with spaces'
+        self.workspace.mkdir()
+        self.bin = self.root / 'bin'
+        self.bin.mkdir()
+        self.log = self.root / 'calls.jsonl'
+        self.env = {**os.environ, 'PATH': f'{self.bin}:{os.environ["PATH"]}',
+                    'HOOK_CALLS': str(self.log), 'HOOK_MODE': 'normal', 'REPOQL_CWD': '/wrong-workspace'}
+        (self.bin / 'rql').write_text('''#!/usr/bin/env python3
+import json, os, sys
+with open(os.environ['HOOK_CALLS'], 'a') as log:
+    log.write(json.dumps({'args': sys.argv[1:], 'cwd': os.getcwd(), 'workspace_pin': os.environ.get('REPOQL_CWD'), 'content': sys.stdin.read()}) + '\\n')
+if os.environ['HOOK_MODE'] == 'failure':
+    print('host unavailable', file=sys.stderr)
+    sys.exit(1)
+if os.environ['HOOK_MODE'] != 'empty':
+    print('DirtySweep [engine] — The dirty-file actor.')
+''')
+        (self.bin / 'rql').chmod(0o755)
+
+    def run_hook(self, harness, **overrides):
+        payload = {'hook_event_name': 'PostToolUse', 'session_id': 'read-session',
+                   'cwd': str(self.workspace), 'tool_name': 'Read',
+                   'tool_input': {'file_path': str(self.workspace / 'src/A.cs')},
+                   'tool_response': {'type': 'text', 'file': {
+                       'filePath': str(self.workspace / 'src/A.cs'), 'content': 'DirtySweep works.',
+                       'numLines': 1, 'startLine': 1, 'totalLines': 20}}}
+        payload.update(overrides)
+        result = subprocess.run(['bash', str(ROOT / 'plugins' / harness / 'scripts/vocabulary-read-hook.sh')],
+                                input=json.dumps(payload), text=True, capture_output=True,
+                                env=self.env, cwd=self.root, timeout=5)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result
+
+    def calls(self):
+        return [json.loads(line) for line in self.log.read_text().splitlines()] if self.log.exists() else []
+
+    def test_native_read_delivers_definition_with_session_scope_and_workspace(self):
+        for harness in HARNESSES:
+            with self.subTest(harness=harness):
+                result = self.run_hook(harness)
+                self.assertEqual(result.stderr, '')
+                self.assertEqual(json.loads(result.stdout), {'hookSpecificOutput': {
+                    'hookEventName': 'PostToolUse',
+                    'additionalContext': 'DirtySweep [engine] — The dirty-file actor.'}})
+                self.assertEqual(self.calls()[-1], {'cwd': str(self.workspace), 'workspace_pin': str(self.workspace), 'content': 'DirtySweep works.',
+                    'args': ['vocabulary', 'hints', str(self.workspace / 'src/A.cs'), '--session', 'read-session',
+                             '--limit', '5', '--max-chars', '2000']})
+
+    def test_mcp_text_blocks_and_uri_modifiers(self):
+        for harness in HARNESSES:
+            with self.subTest(harness=harness):
+                self.run_hook(harness, tool_name='mcp__plugin_repoql_repoql__read',
+                    tool_input={'uriGlob': 'file:///src/**/*.cs#line=1,5 => content', 'keywords': 'NeverMatchArguments'},
+                    tool_response={'content': [{'type': 'text', 'text': 'DirtySweep'},
+                                               {'type': 'image', 'data': 'NeverMatchImage'},
+                                               {'type': 'text', 'text': 'file watcher'}], 'isError': False})
+                call = self.calls()[-1]
+                self.assertEqual(call['content'], 'DirtySweep\nfile watcher')
+                self.assertEqual(call['args'][2], 'file:///src/**/*.cs')
+
+    def test_plain_text_response(self):
+        for harness in HARNESSES:
+            self.run_hook(harness, tool_name='read_file', tool_input={'path': 'src/A.cs'}, tool_response='file watcher')
+            self.assertEqual(self.calls()[-1]['content'], 'file watcher')
+            self.assertEqual(self.calls()[-1]['args'][2], str(self.workspace / 'src/A.cs'))
+
+    def test_empty_errors_images_metadata_and_unrelated_tools_do_not_call_cli(self):
+        for harness in HARNESSES:
+            for overrides in [
+                {'tool_response': ''}, {'tool_response': {'isError': True, 'content': 'DirtySweep'}},
+                {'tool_response': {'is_error': True, 'content': 'DirtySweep'}},
+                {'tool_response': {'content': [{'type': 'image', 'data': 'DirtySweep'}]}},
+                {'tool_response': {'structuredContent': {'secret': 'DirtySweep'}}},
+                {'tool_input': {'file_path': 'DirtySweep.cs'}, 'tool_response': {}},
+                {'tool_name': 'Bash'}, {'tool_name': 'mcp__other__read'},
+                {'session_id': ''}, {'cwd': '/does-not-exist'}, {'tool_input': {}}]:
+                with self.subTest(harness=harness, overrides=overrides):
+                    result = self.run_hook(harness, **overrides)
+                    self.assertEqual(result.stdout, '')
+                    self.assertEqual(self.calls(), [])
+
+    def test_bounded_unicode_content_prefix(self):
+        for harness in HARNESSES:
+            self.run_hook(harness, tool_response='🙂' * 70000)
+            self.assertEqual(self.calls()[-1]['content'], '🙂' * 65536)
+
+    def test_cli_failure_reports_but_never_blocks_read(self):
+        self.env['HOOK_MODE'] = 'failure'
+        for harness in HARNESSES:
+            result = self.run_hook(harness)
+            self.assertEqual(result.stdout, '')
+            self.assertIn('RepoQL vocabulary hints: CLI failed;', result.stderr)
+
+    def test_no_new_definitions_is_quiet(self):
+        self.env['HOOK_MODE'] = 'empty'
+        for harness in HARNESSES:
+            result = self.run_hook(harness)
+            self.assertEqual((result.stdout, result.stderr), ('', ''))
+
+    def test_hook_registration_covers_supported_reads_only(self):
+        for harness in HARNESSES:
+            config = json.loads((ROOT / 'plugins' / harness / 'hooks/hooks.json').read_text())
+            hook = config['hooks']['PostToolUse'][0]
+            for name in ['Read', 'read_file', 'mcp__repoql__read', 'mcp__plugin_RepoQL_RepoQL__read']:
+                self.assertTrue(re.fullmatch(hook['matcher'], name), name)
+            for name in ['Bash', 'Write', 'mcp__other__read', 'mcp__repoql__read_other']:
+                self.assertFalse(re.fullmatch(hook['matcher'], name), name)
+            self.assertIn('vocabulary-read-hook.sh', hook['hooks'][0]['command'])
+
+    def test_both_adapters_stay_identical(self):
+        self.assertEqual(*[(ROOT / 'plugins' / harness / 'scripts/vocabulary-read-hook.sh').read_bytes()
+                           for harness in HARNESSES])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add Claude and Codex PostToolUse hooks that define known vocabulary found in returned read text. Native `Read`/`read_file` and RepoQL MCP `read` responses call `rql vocabulary hints`; the host owns scope matching and once-per-session suppression across both read paths.

Depends on https://github.com/RepoQL/RepoQL.Core/pull/316. Release the new core host and CLI before activating these plugin versions. Older binaries produce a diagnostic and the read continues.

The adapters forward only returned text, skip failed and image-only responses, and consider the first 65,536 Unicode characters. Each read requests at most five complete definitions within 2,000 characters. Calls pin the workspace to the harness cwd and resolve native relative paths there. Arbitrary shell reads such as `cat` and `sed` are outside this change.

Includes hook registration, plugin version updates, usage/rollout notes, and macOS/Linux CI coverage for both context-hook suites.

Validation:
- All 19 hook tests passed, including literal native/MCP payloads, workspace/session forwarding, input bounds, failed reads, and fail-open CLI behavior.
- Codex plugin validation passed.
- Published core binary: Claude native read received a definition; Codex MCP alias read in the same session stayed quiet; a fresh session received it. Out-of-scope reads and partial names stayed quiet.
