### PR TITLE
Show customer terms beside installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Queryable code intelligence for AI coding agents.
 
 ## Install
 
+By downloading and using RepoQL, you agree to the [Customer Terms and Software Licence](https://repoql.com/terms/2026-09-11/).
+
 **Codex** — [install the RepoQL Codex plugin](plugins/repoql-codex/README.md).
 
 **Claude Code** — one-step plugin install (downloads the `rql` binary automatically on first session):
@@ -19,11 +21,15 @@ Queryable code intelligence for AI coding agents.
 
 **macOS / Linux**
 
+By downloading and using RepoQL, you agree to the [Customer Terms and Software Licence](https://repoql.com/terms/2026-09-11/).
+
 ```sh
 curl -fsSL https://downloads.repoql.ai/latest/install-rql.sh | bash
 ```
 
 **Windows (PowerShell)**
+
+By downloading and using RepoQL, you agree to the [Customer Terms and Software Licence](https://repoql.com/terms/2026-09-11/).
 
 ```powershell
 irm https://downloads.repoql.ai/latest/install-rql.ps1 | iex

--- a/plugins/repoql-codex/README.md
+++ b/plugins/repoql-codex/README.md
@@ -9,6 +9,8 @@ RepoQL gives ChatGPT and Codex a pre-built structural index of a codebase. The p
 
 ## Install
 
+By downloading and using RepoQL, you agree to the [Customer Terms and Software Licence](https://repoql.com/terms/2026-09-11/).
+
 ```sh
 codex plugin marketplace add RepoQL/RepoQL
 codex plugin add repoql-codex@repoql
@@ -17,6 +19,8 @@ codex plugin add repoql-codex@repoql
 Review and trust the plugin hooks when Codex asks. The startup hook installs `rql` from `downloads.repoql.ai` when it is missing, then the bundled MCP configuration starts `rql mcp`. Set `REPOQL_NO_BOOTSTRAP=1` to disable automatic installation.
 
 To install `rql` manually:
+
+By downloading and using RepoQL, you agree to the [Customer Terms and Software Licence](https://repoql.com/terms/2026-09-11/).
 
 ```sh
 # macOS or Linux
@@ -86,4 +90,4 @@ The Claude Code package includes a status-line builder. Codex does not expose a 
 
 ## License
 
-MIT
+The plugin integration files are MIT-licensed. The separately downloaded `rql` software is provided under the [Customer Terms and Software Licence](https://repoql.com/terms/2026-09-11/).


### PR DESCRIPTION
Add a notice linking the published Customer Terms and Software Licence beside RepoQL installation instructions in the main README and Codex plugin README.

Clarify that the plugin integration files remain MIT-licensed and that the separately downloaded `rql` software has its own licence. Installation commands and plugin behaviour are unchanged.

Validation: confirmed the dated terms URL is publicly reachable, reviewed notice placement for plugin and standalone installation routes, and ran `git diff --check`.
